### PR TITLE
Improve error diagnostics

### DIFF
--- a/src/fetchBestTeamsDataFromF1FantasyTools.js
+++ b/src/fetchBestTeamsDataFromF1FantasyTools.js
@@ -1,4 +1,5 @@
 const puppeteer = require('puppeteer');
+const telegramService = require('./telegramService');
 
 exports.fetchBestTeamsDataFromF1FantasyTools = async function () {
   try {
@@ -214,6 +215,18 @@ async function fetchData() {
     return result;
   } catch (error) {
     if (page) {
+      try {
+        const screenshot = await page.screenshot();
+        await telegramService.sendPhoto(
+          screenshot,
+          `Failure screenshot: ${error.message}`,
+        );
+        const html = await page.content();
+        console.error('Page HTML snippet:', html.slice(0, 500));
+      } catch (captureError) {
+        console.error('Failed to capture debug info:', captureError.message);
+      }
+
       await page.close();
     }
     await browser.close();

--- a/src/telegramService.js
+++ b/src/telegramService.js
@@ -27,6 +27,15 @@ class TelegramService {
     }
   }
 
+  async sendPhoto(photoBuffer, caption, chatId = LOG_CHANNEL_ID) {
+    try {
+      await this.bot.sendPhoto(chatId, photoBuffer, { caption });
+      console.log('Telegram photo sent successfully');
+    } catch (error) {
+      console.error('Failed to send Telegram photo:', error.message);
+    }
+  }
+
   formatTimestamp(utcTimestamp) {
     if (!utcTimestamp) {
       return 'Unknown';


### PR DESCRIPTION
## Summary
- send Telegram screenshots on fetch errors
- log snippet of page HTML on failure

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6884decfd334832f9b0cf7c6b79b9863