### PR TITLE
Ensure HTML snippet logs even if screenshot fails

### DIFF
--- a/src/fetchBestTeamsDataFromF1FantasyTools.js
+++ b/src/fetchBestTeamsDataFromF1FantasyTools.js
@@ -216,15 +216,20 @@ async function fetchData() {
   } catch (error) {
     if (page) {
       try {
+        const html = await page.content();
+        console.error('Page HTML snippet:', html.slice(0, 500));
+      } catch (htmlError) {
+        console.error('Failed to capture page HTML:', htmlError.message);
+      }
+
+      try {
         const screenshot = await page.screenshot();
         await telegramService.sendPhoto(
           screenshot,
           `Failure screenshot: ${error.message}`,
         );
-        const html = await page.content();
-        console.error('Page HTML snippet:', html.slice(0, 500));
       } catch (captureError) {
-        console.error('Failed to capture debug info:', captureError.message);
+        console.error('Failed to send screenshot:', captureError.message);
       }
 
       await page.close();


### PR DESCRIPTION
## Summary
- print the page HTML snippet before attempting to send the failure screenshot

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688870a3add8832f9755d7482cf2d7f8