### PR TITLE
[codex] Split scheduler logic apps

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,11 +1,12 @@
 # F1 Fantasy Scraper — Infrastructure
 
-ARM templates for the two Logic Apps that drive the scraper in production:
+ARM templates for the Logic Apps that drive the scraper in production:
 
-| Logic App                      | Trigger                                              | Purpose                                                                                                                                 |
-| ------------------------------ | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `f1-fantasy-scraper-runner`    | HTTP (Request)                                       | Starts the `f1-fantasy-scraper-aci` container group via Managed Identity → Azure Management API.                                        |
-| `f1-fantasy-scraper-scheduler` | Recurrence (Fri/Sat 15 & 45 min + Mon 02/10/18, UTC) | On Fri/Sat: fetches next race and calls runner if `FP1 < now < Qualifying`. On Mon 02:00/10:00/18:00 UTC: calls runner unconditionally. |
+| Logic App                            | Trigger                                 | Purpose                                                                                          |
+| ------------------------------------ | --------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `f1-fantasy-scraper-runner`          | HTTP (Request)                          | Starts the `f1-fantasy-scraper-aci` container group via Managed Identity → Azure Management API. |
+| `f1-fantasy-scraper-scheduler`       | Recurrence (Fri/Sat 15 & 45 min, UTC)  | Fetches next race and calls runner if `FP1 < now < Qualifying`.                                  |
+| `f1-fantasy-scraper-scheduler-post-race` | Recurrence (Mon 02/10/18, UTC)      | Calls runner after race weekends.                                                                |
 
 ## Layout
 
@@ -36,7 +37,7 @@ npm run infra:validate
 # Preview changes (what-if)
 npm run infra:whatif
 
-# Full flow: runner → grant MSI → scheduler
+# Full flow: runner -> grant MSI -> schedulers
 npm run infra:deploy
 
 # Or individual steps
@@ -68,7 +69,7 @@ az deployment group create \
 # 2. Grant the runner's system-assigned MSI permission to start the ACI
 bash scripts/grant-runner-msi.sh
 
-# 3. Scheduler
+# 3. Schedulers
 az deployment group create \
   --resource-group f1-fantazy-bot \
   --template-file infra/scheduler/azuredeploy.json \
@@ -82,7 +83,7 @@ az deployment group create \
 ## Design notes
 
 - **Runner uses System-Assigned Managed Identity** (no Azure API Connection needed). The MSI must hold a role granting `Microsoft.ContainerInstance/containerGroups/start/action` on the ACI — Contributor at the ACI scope is the simplest fit.
-- **Scheduler → Runner auth is SAS**: the scheduler template calls `listCallbackUrl()` at deploy time, so the SAS-signed URL is always fresh and never hardcoded in source.
-- **Two triggers, one Logic App:** the scheduler has a weekend `Recurrence` (Fri/Sat 15 & 45 past every hour) and a separate `Recurrence_Monday` (Mon 02/10/18). A top-level `If_Monday_Trigger` action branches on `workflow()?['run']?['trigger']?['name']`: Monday runs call the runner directly; weekend runs execute the FP1→Qualifying window check.
+- **Scheduler -> Runner auth is SAS**: the scheduler template calls `listCallbackUrl()` at deploy time, so the SAS-signed URL is always fresh and never hardcoded in source.
+- **Two single-trigger scheduler Logic Apps:** `f1-fantasy-scraper-scheduler` handles the Fri/Sat FP1-to-Qualifying window check. `f1-fantasy-scraper-scheduler-post-race` handles the post-race 02:00/10:00/18:00 UTC runner calls. Splitting the workflows keeps each one compatible with the Azure Logic Apps Designer.
 - **Idempotent:** Re-running the deployment updates the workflow definitions in place.
 - **Replacing existing portal-created Logic Apps:** The first deploy will overwrite the current definitions. Behavior is equivalent but action names differ (e.g., `Start_ACI` replaces the previous `aci-1` connector action).

--- a/infra/scheduler/azuredeploy.json
+++ b/infra/scheduler/azuredeploy.json
@@ -6,14 +6,21 @@
       "type": "string",
       "defaultValue": "f1-fantasy-scraper-scheduler",
       "metadata": {
-        "description": "Name of the scheduler Logic App resource."
+        "description": "Name of the weekend scheduler Logic App resource."
+      }
+    },
+    "postRaceLogicAppName": {
+      "type": "string",
+      "defaultValue": "f1-fantasy-scraper-scheduler-post-race",
+      "metadata": {
+        "description": "Name of the post-race scheduler Logic App resource."
       }
     },
     "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
-        "description": "Azure region for the Logic App."
+        "description": "Azure region for the Logic Apps."
       }
     },
     "runnerLogicAppName": {
@@ -59,8 +66,139 @@
                   "minutes": [15, 45]
                 }
               }
+            }
+          },
+          "actions": {
+            "Fetch_Next_Race": {
+              "type": "Http",
+              "inputs": {
+                "method": "GET",
+                "uri": "[parameters('nextRaceApiUrl')]"
+              },
+              "runtimeConfiguration": {
+                "contentTransfer": {
+                  "transferMode": "Chunked"
+                }
+              },
+              "runAfter": {}
             },
-            "Recurrence_Monday": {
+            "Parse_JSON": {
+              "type": "ParseJson",
+              "inputs": {
+                "content": "@body('Fetch_Next_Race')",
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "MRData": {
+                      "type": "object",
+                      "properties": {
+                        "RaceTable": {
+                          "type": "object",
+                          "properties": {
+                            "Races": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "FirstPractice": {
+                                    "type": "object",
+                                    "properties": {
+                                      "date": { "type": "string" },
+                                      "time": { "type": "string" }
+                                    }
+                                  },
+                                  "Qualifying": {
+                                    "type": "object",
+                                    "properties": {
+                                      "date": { "type": "string" },
+                                      "time": { "type": "string" }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "runAfter": {
+                "Fetch_Next_Race": ["Succeeded"]
+              }
+            },
+            "Compose_FirstPractice_DateTime": {
+              "type": "Compose",
+              "inputs": "@concat(\n  body('Parse_JSON')?['MRData']?['RaceTable']?['Races'][0]?['FirstPractice']?['date'],\n  'T',\n  body('Parse_JSON')?['MRData']?['RaceTable']?['Races'][0]?['FirstPractice']?['time']\n)",
+              "runAfter": {
+                "Parse_JSON": ["Succeeded"]
+              }
+            },
+            "Compose_Qualifying_DateTime": {
+              "type": "Compose",
+              "inputs": "@concat(\n  body('Parse_JSON')?['MRData']?['RaceTable']?['Races'][0]?['Qualifying']?['date'],\n  'T',\n  body('Parse_JSON')?['MRData']?['RaceTable']?['Races'][0]?['Qualifying']?['time']\n)",
+              "runAfter": {
+                "Compose_FirstPractice_DateTime": ["Succeeded"]
+              }
+            },
+            "If_Within_FP1_to_Qualifying_Window": {
+              "type": "If",
+              "expression": {
+                "and": [
+                  {
+                    "greater": [
+                      "@utcNow()",
+                      "@outputs('Compose_FirstPractice_DateTime')"
+                    ]
+                  },
+                  {
+                    "less": [
+                      "@utcNow()",
+                      "@outputs('Compose_Qualifying_DateTime')"
+                    ]
+                  }
+                ]
+              },
+              "actions": {
+                "Trigger_Runner": {
+                  "type": "Http",
+                  "inputs": {
+                    "method": "POST",
+                    "uri": "[listCallbackUrl(resourceId('Microsoft.Logic/workflows/triggers', parameters('runnerLogicAppName'), 'manual'), '2016-06-01').value]"
+                  },
+                  "runtimeConfiguration": {
+                    "contentTransfer": {
+                      "transferMode": "Chunked"
+                    }
+                  },
+                  "runAfter": {}
+                }
+              },
+              "else": {
+                "actions": {}
+              },
+              "runAfter": {
+                "Compose_Qualifying_DateTime": ["Succeeded"]
+              }
+            }
+          },
+          "outputs": {}
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Logic/workflows",
+      "apiVersion": "2019-05-01",
+      "name": "[parameters('postRaceLogicAppName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "state": "Enabled",
+        "definition": {
+          "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+          "contentVersion": "1.0.0.0",
+          "triggers": {
+            "Recurrence": {
               "type": "Recurrence",
               "recurrence": {
                 "frequency": "Week",
@@ -75,144 +213,15 @@
             }
           },
           "actions": {
-            "If_Monday_Trigger": {
-              "type": "If",
-              "expression": {
-                "equals": [
-                  "@workflow()?['run']?['trigger']?['name']",
-                  "Recurrence_Monday"
-                ]
+            "Trigger_Runner_Post_Race": {
+              "type": "Http",
+              "inputs": {
+                "method": "POST",
+                "uri": "[listCallbackUrl(resourceId('Microsoft.Logic/workflows/triggers', parameters('runnerLogicAppName'), 'manual'), '2016-06-01').value]"
               },
-              "actions": {
-                "Trigger_Runner_Monday": {
-                  "type": "Http",
-                  "inputs": {
-                    "method": "GET",
-                    "uri": "[listCallbackUrl(resourceId('Microsoft.Logic/workflows/triggers', parameters('runnerLogicAppName'), 'manual'), '2016-06-01').value]"
-                  },
-                  "runtimeConfiguration": {
-                    "contentTransfer": {
-                      "transferMode": "Chunked"
-                    }
-                  },
-                  "runAfter": {}
-                }
-              },
-              "else": {
-                "actions": {
-                  "Fetch_Next_Race": {
-                    "type": "Http",
-                    "inputs": {
-                      "method": "GET",
-                      "uri": "[parameters('nextRaceApiUrl')]"
-                    },
-                    "runtimeConfiguration": {
-                      "contentTransfer": {
-                        "transferMode": "Chunked"
-                      }
-                    },
-                    "runAfter": {}
-                  },
-                  "Parse_JSON": {
-                    "type": "ParseJson",
-                    "inputs": {
-                      "content": "@body('Fetch_Next_Race')",
-                      "schema": {
-                        "type": "object",
-                        "properties": {
-                          "MRData": {
-                            "type": "object",
-                            "properties": {
-                              "RaceTable": {
-                                "type": "object",
-                                "properties": {
-                                  "Races": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "properties": {
-                                        "FirstPractice": {
-                                          "type": "object",
-                                          "properties": {
-                                            "date": { "type": "string" },
-                                            "time": { "type": "string" }
-                                          }
-                                        },
-                                        "Qualifying": {
-                                          "type": "object",
-                                          "properties": {
-                                            "date": { "type": "string" },
-                                            "time": { "type": "string" }
-                                          }
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "runAfter": {
-                      "Fetch_Next_Race": ["Succeeded"]
-                    }
-                  },
-                  "Compose_FirstPractice_DateTime": {
-                    "type": "Compose",
-                    "inputs": "@concat(\n  body('Parse_JSON')?['MRData']?['RaceTable']?['Races'][0]?['FirstPractice']?['date'],\n  'T',\n  body('Parse_JSON')?['MRData']?['RaceTable']?['Races'][0]?['FirstPractice']?['time']\n)",
-                    "runAfter": {
-                      "Parse_JSON": ["Succeeded"]
-                    }
-                  },
-                  "Compose_Qualifying_DateTime": {
-                    "type": "Compose",
-                    "inputs": "@concat(\n  body('Parse_JSON')?['MRData']?['RaceTable']?['Races'][0]?['Qualifying']?['date'],\n  'T',\n  body('Parse_JSON')?['MRData']?['RaceTable']?['Races'][0]?['Qualifying']?['time']\n)",
-                    "runAfter": {
-                      "Compose_FirstPractice_DateTime": ["Succeeded"]
-                    }
-                  },
-                  "If_Within_FP1_to_Qualifying_Window": {
-                    "type": "If",
-                    "expression": {
-                      "and": [
-                        {
-                          "greater": [
-                            "@utcNow()",
-                            "@outputs('Compose_FirstPractice_DateTime')"
-                          ]
-                        },
-                        {
-                          "less": [
-                            "@utcNow()",
-                            "@outputs('Compose_Qualifying_DateTime')"
-                          ]
-                        }
-                      ]
-                    },
-                    "actions": {
-                      "Trigger_Runner": {
-                        "type": "Http",
-                        "inputs": {
-                          "method": "GET",
-                          "uri": "[listCallbackUrl(resourceId('Microsoft.Logic/workflows/triggers', parameters('runnerLogicAppName'), 'manual'), '2016-06-01').value]"
-                        },
-                        "runtimeConfiguration": {
-                          "contentTransfer": {
-                            "transferMode": "Chunked"
-                          }
-                        },
-                        "runAfter": {}
-                      }
-                    },
-                    "else": {
-                      "actions": {}
-                    },
-                    "runAfter": {
-                      "Compose_Qualifying_DateTime": ["Succeeded"]
-                    }
-                  }
+              "runtimeConfiguration": {
+                "contentTransfer": {
+                  "transferMode": "Chunked"
                 }
               },
               "runAfter": {}
@@ -227,6 +236,10 @@
     "logicAppResourceId": {
       "type": "string",
       "value": "[resourceId('Microsoft.Logic/workflows', parameters('logicAppName'))]"
+    },
+    "postRaceLogicAppResourceId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Logic/workflows', parameters('postRaceLogicAppName'))]"
     }
   }
 }

--- a/infra/scheduler/azuredeploy.parameters.json
+++ b/infra/scheduler/azuredeploy.parameters.json
@@ -5,6 +5,9 @@
     "logicAppName": {
       "value": "f1-fantasy-scraper-scheduler"
     },
+    "postRaceLogicAppName": {
+      "value": "f1-fantasy-scraper-scheduler-post-race"
+    },
     "location": {
       "value": "westeurope"
     },


### PR DESCRIPTION
## Summary

- Split the scheduler ARM template into two single-trigger Logic Apps so each workflow can open in the Azure Logic Apps Designer.
- Keep the existing weekend race-window scheduler as `f1-fantasy-scraper-scheduler`.
- Add `f1-fantasy-scraper-scheduler-post-race` for post-race Monday runs.
- Change scheduler-to-runner invocations from `GET` to `POST` to match the runner HTTP trigger.
- Update infra docs and scheduler parameters for the new post-race resource.

## Validation

- Parsed scheduler ARM template and parameter JSON locally.
- Ran `npm run infra:validate:scheduler` successfully against Azure after the split and POST fix.