### PR TITLE
Add Telegram failure notifications to Logic Apps

### DIFF
--- a/infra/runner/azuredeploy.json
+++ b/infra/runner/azuredeploy.json
@@ -36,6 +36,12 @@
       "metadata": {
         "description": "Name of the ACI container group to start."
       }
+    },
+    "telegramBotToken": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Telegram bot token used to post Logic App failure notifications."
+      }
     }
   },
   "variables": {
@@ -65,29 +71,65 @@
             }
           },
           "actions": {
-            "Start_ACI": {
-              "type": "Http",
-              "inputs": {
-                "method": "POST",
-                "uri": "[variables('aciStartUri')]",
-                "authentication": {
-                  "type": "ManagedServiceIdentity",
-                  "audience": "https://management.azure.com/"
+            "Try": {
+              "type": "Scope",
+              "actions": {
+                "Start_ACI": {
+                  "type": "Http",
+                  "inputs": {
+                    "method": "POST",
+                    "uri": "[variables('aciStartUri')]",
+                    "authentication": {
+                      "type": "ManagedServiceIdentity",
+                      "audience": "https://management.azure.com/"
+                    }
+                  },
+                  "runAfter": {}
+                },
+                "Return_Success": {
+                  "type": "Response",
+                  "kind": "Http",
+                  "inputs": {
+                    "statusCode": 200,
+                    "body": {
+                      "status": "start_requested"
+                    }
+                  },
+                  "runAfter": {
+                    "Start_ACI": ["Succeeded"]
+                  }
                 }
               },
               "runAfter": {}
             },
-            "Return_Success": {
-              "type": "Response",
-              "kind": "Http",
+            "Notify_Log_Channel_On_Failure": {
+              "type": "Http",
               "inputs": {
-                "statusCode": 200,
+                "method": "POST",
+                "uri": "[concat('https://api.telegram.org/bot', parameters('telegramBotToken'), '/sendMessage')]",
+                "headers": { "Content-Type": "application/json" },
                 "body": {
-                  "status": "start_requested"
+                  "chat_id": -1002298860617,
+                  "text": "@{concat('🚨 Logic App ', workflow().name, ' failed\n\nRun: ', workflow().run.name, '\nTime (UTC): ', utcNow(), '\n\nFailed actions:\n', take(string(filter(result('Try'), equals(item()?['status'], 'Failed'))), 3500))}"
                 }
               },
               "runAfter": {
-                "Start_ACI": ["Succeeded"]
+                "Try": ["Failed", "TimedOut"]
+              }
+            },
+            "Notify_Errors_Channel_On_Failure": {
+              "type": "Http",
+              "inputs": {
+                "method": "POST",
+                "uri": "[concat('https://api.telegram.org/bot', parameters('telegramBotToken'), '/sendMessage')]",
+                "headers": { "Content-Type": "application/json" },
+                "body": {
+                  "chat_id": -5167373779,
+                  "text": "@{concat('🚨 Logic App ', workflow().name, ' failed\n\nRun: ', workflow().run.name, '\nTime (UTC): ', utcNow(), '\n\nFailed actions:\n', take(string(filter(result('Try'), equals(item()?['status'], 'Failed'))), 3500))}"
+                }
+              },
+              "runAfter": {
+                "Try": ["Failed", "TimedOut"]
               }
             }
           }

--- a/infra/runner/azuredeploy.parameters.json
+++ b/infra/runner/azuredeploy.parameters.json
@@ -16,6 +16,14 @@
     },
     "containerGroupName": {
       "value": "f1-fantasy-scraper-aci"
+    },
+    "telegramBotToken": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/5cfc4033-d828-4bdb-b9ea-de042e483715/resourceGroups/f1-fantazy-bot/providers/Microsoft.KeyVault/vaults/f1-fantasy-kv"
+        },
+        "secretName": "telegram-bot-token"
+      }
     }
   }
 }

--- a/infra/scheduler/azuredeploy.json
+++ b/infra/scheduler/azuredeploy.json
@@ -36,6 +36,12 @@
       "metadata": {
         "description": "Ergast-compatible endpoint used to look up the next race schedule."
       }
+    },
+    "telegramBotToken": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Telegram bot token used to post Logic App failure notifications."
+      }
     }
   },
   "variables": {},
@@ -69,49 +75,54 @@
             }
           },
           "actions": {
-            "Fetch_Next_Race": {
-              "type": "Http",
-              "inputs": {
-                "method": "GET",
-                "uri": "[parameters('nextRaceApiUrl')]"
-              },
-              "runtimeConfiguration": {
-                "contentTransfer": {
-                  "transferMode": "Chunked"
-                }
-              },
-              "runAfter": {}
-            },
-            "Parse_JSON": {
-              "type": "ParseJson",
-              "inputs": {
-                "content": "@body('Fetch_Next_Race')",
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "MRData": {
+            "Try": {
+              "type": "Scope",
+              "actions": {
+                "Fetch_Next_Race": {
+                  "type": "Http",
+                  "inputs": {
+                    "method": "GET",
+                    "uri": "[parameters('nextRaceApiUrl')]"
+                  },
+                  "runtimeConfiguration": {
+                    "contentTransfer": {
+                      "transferMode": "Chunked"
+                    }
+                  },
+                  "runAfter": {}
+                },
+                "Parse_JSON": {
+                  "type": "ParseJson",
+                  "inputs": {
+                    "content": "@body('Fetch_Next_Race')",
+                    "schema": {
                       "type": "object",
                       "properties": {
-                        "RaceTable": {
+                        "MRData": {
                           "type": "object",
                           "properties": {
-                            "Races": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "FirstPractice": {
+                            "RaceTable": {
+                              "type": "object",
+                              "properties": {
+                                "Races": {
+                                  "type": "array",
+                                  "items": {
                                     "type": "object",
                                     "properties": {
-                                      "date": { "type": "string" },
-                                      "time": { "type": "string" }
-                                    }
-                                  },
-                                  "Qualifying": {
-                                    "type": "object",
-                                    "properties": {
-                                      "date": { "type": "string" },
-                                      "time": { "type": "string" }
+                                      "FirstPractice": {
+                                        "type": "object",
+                                        "properties": {
+                                          "date": { "type": "string" },
+                                          "time": { "type": "string" }
+                                        }
+                                      },
+                                      "Qualifying": {
+                                        "type": "object",
+                                        "properties": {
+                                          "date": { "type": "string" },
+                                          "time": { "type": "string" }
+                                        }
+                                      }
                                     }
                                   }
                                 }
@@ -121,65 +132,96 @@
                         }
                       }
                     }
+                  },
+                  "runAfter": {
+                    "Fetch_Next_Race": ["Succeeded"]
                   }
-                }
-              },
-              "runAfter": {
-                "Fetch_Next_Race": ["Succeeded"]
-              }
-            },
-            "Compose_FirstPractice_DateTime": {
-              "type": "Compose",
-              "inputs": "@concat(\n  body('Parse_JSON')?['MRData']?['RaceTable']?['Races'][0]?['FirstPractice']?['date'],\n  'T',\n  body('Parse_JSON')?['MRData']?['RaceTable']?['Races'][0]?['FirstPractice']?['time']\n)",
-              "runAfter": {
-                "Parse_JSON": ["Succeeded"]
-              }
-            },
-            "Compose_Qualifying_DateTime": {
-              "type": "Compose",
-              "inputs": "@concat(\n  body('Parse_JSON')?['MRData']?['RaceTable']?['Races'][0]?['Qualifying']?['date'],\n  'T',\n  body('Parse_JSON')?['MRData']?['RaceTable']?['Races'][0]?['Qualifying']?['time']\n)",
-              "runAfter": {
-                "Compose_FirstPractice_DateTime": ["Succeeded"]
-              }
-            },
-            "If_Within_FP1_to_Qualifying_Window": {
-              "type": "If",
-              "expression": {
-                "and": [
-                  {
-                    "greater": [
-                      "@utcNow()",
-                      "@outputs('Compose_FirstPractice_DateTime')"
+                },
+                "Compose_FirstPractice_DateTime": {
+                  "type": "Compose",
+                  "inputs": "@concat(\n  body('Parse_JSON')?['MRData']?['RaceTable']?['Races'][0]?['FirstPractice']?['date'],\n  'T',\n  body('Parse_JSON')?['MRData']?['RaceTable']?['Races'][0]?['FirstPractice']?['time']\n)",
+                  "runAfter": {
+                    "Parse_JSON": ["Succeeded"]
+                  }
+                },
+                "Compose_Qualifying_DateTime": {
+                  "type": "Compose",
+                  "inputs": "@concat(\n  body('Parse_JSON')?['MRData']?['RaceTable']?['Races'][0]?['Qualifying']?['date'],\n  'T',\n  body('Parse_JSON')?['MRData']?['RaceTable']?['Races'][0]?['Qualifying']?['time']\n)",
+                  "runAfter": {
+                    "Compose_FirstPractice_DateTime": ["Succeeded"]
+                  }
+                },
+                "If_Within_FP1_to_Qualifying_Window": {
+                  "type": "If",
+                  "expression": {
+                    "and": [
+                      {
+                        "greater": [
+                          "@utcNow()",
+                          "@outputs('Compose_FirstPractice_DateTime')"
+                        ]
+                      },
+                      {
+                        "less": [
+                          "@utcNow()",
+                          "@outputs('Compose_Qualifying_DateTime')"
+                        ]
+                      }
                     ]
                   },
-                  {
-                    "less": [
-                      "@utcNow()",
-                      "@outputs('Compose_Qualifying_DateTime')"
-                    ]
-                  }
-                ]
-              },
-              "actions": {
-                "Trigger_Runner": {
-                  "type": "Http",
-                  "inputs": {
-                    "method": "POST",
-                    "uri": "[listCallbackUrl(resourceId('Microsoft.Logic/workflows/triggers', parameters('runnerLogicAppName'), 'manual'), '2016-06-01').value]"
-                  },
-                  "runtimeConfiguration": {
-                    "contentTransfer": {
-                      "transferMode": "Chunked"
+                  "actions": {
+                    "Trigger_Runner": {
+                      "type": "Http",
+                      "inputs": {
+                        "method": "POST",
+                        "uri": "[listCallbackUrl(resourceId('Microsoft.Logic/workflows/triggers', parameters('runnerLogicAppName'), 'manual'), '2016-06-01').value]"
+                      },
+                      "runtimeConfiguration": {
+                        "contentTransfer": {
+                          "transferMode": "Chunked"
+                        }
+                      },
+                      "runAfter": {}
                     }
                   },
-                  "runAfter": {}
+                  "else": {
+                    "actions": {}
+                  },
+                  "runAfter": {
+                    "Compose_Qualifying_DateTime": ["Succeeded"]
+                  }
                 }
               },
-              "else": {
-                "actions": {}
+              "runAfter": {}
+            },
+            "Notify_Log_Channel_On_Failure": {
+              "type": "Http",
+              "inputs": {
+                "method": "POST",
+                "uri": "[concat('https://api.telegram.org/bot', parameters('telegramBotToken'), '/sendMessage')]",
+                "headers": { "Content-Type": "application/json" },
+                "body": {
+                  "chat_id": -1002298860617,
+                  "text": "@{concat('🚨 Logic App ', workflow().name, ' failed\n\nRun: ', workflow().run.name, '\nTime (UTC): ', utcNow(), '\n\nFailed actions:\n', take(string(filter(result('Try'), equals(item()?['status'], 'Failed'))), 3500))}"
+                }
               },
               "runAfter": {
-                "Compose_Qualifying_DateTime": ["Succeeded"]
+                "Try": ["Failed", "TimedOut"]
+              }
+            },
+            "Notify_Errors_Channel_On_Failure": {
+              "type": "Http",
+              "inputs": {
+                "method": "POST",
+                "uri": "[concat('https://api.telegram.org/bot', parameters('telegramBotToken'), '/sendMessage')]",
+                "headers": { "Content-Type": "application/json" },
+                "body": {
+                  "chat_id": -5167373779,
+                  "text": "@{concat('🚨 Logic App ', workflow().name, ' failed\n\nRun: ', workflow().run.name, '\nTime (UTC): ', utcNow(), '\n\nFailed actions:\n', take(string(filter(result('Try'), equals(item()?['status'], 'Failed'))), 3500))}"
+                }
+              },
+              "runAfter": {
+                "Try": ["Failed", "TimedOut"]
               }
             }
           },
@@ -213,18 +255,54 @@
             }
           },
           "actions": {
-            "Trigger_Runner_Post_Race": {
-              "type": "Http",
-              "inputs": {
-                "method": "POST",
-                "uri": "[listCallbackUrl(resourceId('Microsoft.Logic/workflows/triggers', parameters('runnerLogicAppName'), 'manual'), '2016-06-01').value]"
-              },
-              "runtimeConfiguration": {
-                "contentTransfer": {
-                  "transferMode": "Chunked"
+            "Try": {
+              "type": "Scope",
+              "actions": {
+                "Trigger_Runner_Post_Race": {
+                  "type": "Http",
+                  "inputs": {
+                    "method": "POST",
+                    "uri": "[listCallbackUrl(resourceId('Microsoft.Logic/workflows/triggers', parameters('runnerLogicAppName'), 'manual'), '2016-06-01').value]"
+                  },
+                  "runtimeConfiguration": {
+                    "contentTransfer": {
+                      "transferMode": "Chunked"
+                    }
+                  },
+                  "runAfter": {}
                 }
               },
               "runAfter": {}
+            },
+            "Notify_Log_Channel_On_Failure": {
+              "type": "Http",
+              "inputs": {
+                "method": "POST",
+                "uri": "[concat('https://api.telegram.org/bot', parameters('telegramBotToken'), '/sendMessage')]",
+                "headers": { "Content-Type": "application/json" },
+                "body": {
+                  "chat_id": -1002298860617,
+                  "text": "@{concat('🚨 Logic App ', workflow().name, ' failed\n\nRun: ', workflow().run.name, '\nTime (UTC): ', utcNow(), '\n\nFailed actions:\n', take(string(filter(result('Try'), equals(item()?['status'], 'Failed'))), 3500))}"
+                }
+              },
+              "runAfter": {
+                "Try": ["Failed", "TimedOut"]
+              }
+            },
+            "Notify_Errors_Channel_On_Failure": {
+              "type": "Http",
+              "inputs": {
+                "method": "POST",
+                "uri": "[concat('https://api.telegram.org/bot', parameters('telegramBotToken'), '/sendMessage')]",
+                "headers": { "Content-Type": "application/json" },
+                "body": {
+                  "chat_id": -5167373779,
+                  "text": "@{concat('🚨 Logic App ', workflow().name, ' failed\n\nRun: ', workflow().run.name, '\nTime (UTC): ', utcNow(), '\n\nFailed actions:\n', take(string(filter(result('Try'), equals(item()?['status'], 'Failed'))), 3500))}"
+                }
+              },
+              "runAfter": {
+                "Try": ["Failed", "TimedOut"]
+              }
             }
           },
           "outputs": {}

--- a/infra/scheduler/azuredeploy.parameters.json
+++ b/infra/scheduler/azuredeploy.parameters.json
@@ -16,6 +16,14 @@
     },
     "nextRaceApiUrl": {
       "value": "https://api.jolpi.ca/ergast/f1/current/next.json"
+    },
+    "telegramBotToken": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/5cfc4033-d828-4bdb-b9ea-de042e483715/resourceGroups/f1-fantazy-bot/providers/Microsoft.KeyVault/vaults/f1-fantasy-kv"
+        },
+        "secretName": "telegram-bot-token"
+      }
     }
   }
 }


### PR DESCRIPTION
Adds Telegram failure alerts to all Logic Apps in this repo.

## What changed
- Wrapped existing workflow actions in a `Try` Scope (behaviour preserved).
- Added two HTTP actions after `Try` that POST to Telegram `sendMessage` on `Failed`/`TimedOut`:
  - `Notify_Log_Channel_On_Failure` → chat `-1002298860617` (LOG_CHANNEL_ID)
  - `Notify_Errors_Channel_On_Failure` → chat `-5167373779` (ERRORS_CHANNEL_ID)
- Message contains Logic App name, run ID, UTC time, and filtered `@result('Try')` (truncated to 3500 chars).
- New `telegramBotToken` secureString template parameter, sourced from existing KeyVault secret `telegram-bot-token` in `f1-fantasy-kv`.

Renders cleanly in the portal designer as two collapsible Scopes (Try + Catch).
