### PR TITLE
Logic App: don't mark successful runs as failed

### DIFF
--- a/infra/runner/azuredeploy.json
+++ b/infra/runner/azuredeploy.json
@@ -151,8 +151,8 @@
                 }
               },
               "runAfter": {
-                "Notify_Log_Channel_On_Failure": ["Succeeded", "Failed", "Skipped", "TimedOut"],
-                "Notify_Errors_Channel_On_Failure": ["Succeeded", "Failed", "Skipped", "TimedOut"]
+                "Notify_Log_Channel_On_Failure": ["Succeeded", "Failed", "TimedOut"],
+                "Notify_Errors_Channel_On_Failure": ["Succeeded", "Failed", "TimedOut"]
               }
             }
           }

--- a/infra/scheduler/azuredeploy.json
+++ b/infra/scheduler/azuredeploy.json
@@ -243,8 +243,8 @@
                 }
               },
               "runAfter": {
-                "Notify_Log_Channel_On_Failure": ["Succeeded", "Failed", "Skipped", "TimedOut"],
-                "Notify_Errors_Channel_On_Failure": ["Succeeded", "Failed", "Skipped", "TimedOut"]
+                "Notify_Log_Channel_On_Failure": ["Succeeded", "Failed", "TimedOut"],
+                "Notify_Errors_Channel_On_Failure": ["Succeeded", "Failed", "TimedOut"]
               }
             }
           },
@@ -351,8 +351,8 @@
                 }
               },
               "runAfter": {
-                "Notify_Log_Channel_On_Failure": ["Succeeded", "Failed", "Skipped", "TimedOut"],
-                "Notify_Errors_Channel_On_Failure": ["Succeeded", "Failed", "Skipped", "TimedOut"]
+                "Notify_Log_Channel_On_Failure": ["Succeeded", "Failed", "TimedOut"],
+                "Notify_Errors_Channel_On_Failure": ["Succeeded", "Failed", "TimedOut"]
               }
             }
           },


### PR DESCRIPTION
# Logic App: don't mark successful runs as failed

## Bug

The Terminate action added in the previous PR had:

```json
"runAfter": {
  "Notify_Log_Channel_On_Failure":    ["Succeeded", "Failed", "Skipped", "TimedOut"],
  "Notify_Errors_Channel_On_Failure": ["Succeeded", "Failed", "Skipped", "TimedOut"]
}
```

Logic Apps runs an action when a predecessor's actual status is in its `runAfter` list. On the happy path:

1. Try scope → **Succeeded**
2. Notify actions → **Skipped** (their own `runAfter` requires Try = Failed/TimedOut)
3. Terminate → `"Skipped"` is in its list, so it **runs** anyway, sets `runStatus: Failed` → overall run marked Failed. ❌

## Fix

Drop `"Skipped"` from Terminate's `runAfter`:

```json
"runAfter": {
  "Notify_Log_Channel_On_Failure":    ["Succeeded", "Failed", "TimedOut"],
  "Notify_Errors_Channel_On_Failure": ["Succeeded", "Failed", "TimedOut"]
}
```

Now:

- Try **succeeds** → notify actions Skipped → Terminate Skipped → run = **Succeeded** ✓
- Try **fails** → notify actions run (Succeeded, Failed, or TimedOut) → Terminate runs → run = **Failed** ✓
- Try fails + notify itself fails/times-out → Terminate still runs (those statuses are still in the list) → run = **Failed** ✓
